### PR TITLE
Fix createPublic extension parsing on recover-potential

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ lib: ${SRC_FILES} package.json tsconfig.json node_modules rollup.config.js
 	@${BIN}/rollup -c && touch lib
 
 .PHONY: test
-test: node_modules
+test: lib node_modules
 	@TS_NODE_PROJECT='./test/tsconfig.json' \
 		${BIN}/mocha ${MOCHA_OPTS} test/*.ts --grep '$(grep)'
 
-build/coverage: ${SRC_FILES} ${TEST_FILES} node_modules
+build/coverage: ${SRC_FILES} ${TEST_FILES} lib node_modules
 	@TS_NODE_PROJECT='./test/tsconfig.json' \
 		${BIN}/nyc ${NYC_OPTS} --reporter=html \
 		${BIN}/mocha ${MOCHA_OPTS} -R nyan test/*.ts
@@ -23,7 +23,7 @@ coverage: build/coverage
 	@open build/coverage/index.html
 
 .PHONY: ci-test
-ci-test: node_modules
+ci-test: lib node_modules
 	@TS_NODE_PROJECT='./test/tsconfig.json' \
 		${BIN}/nyc ${NYC_OPTS} --reporter=text \
 		${BIN}/mocha ${MOCHA_OPTS} -R list test/*.ts

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "dependencies": {
         "@wharfkit/antelope": "^1.1.0-rc1",
-        "cborg": "^1.5.0",
+        "cborg": "^4.5.8",
         "elliptic": "^6.5.4",
         "tslib": "^2.1.0"
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,9 @@ import dts from 'rollup-plugin-dts'
 import typescript from '@rollup/plugin-typescript'
 
 import pkg from './package.json'
+import commonjs from '@rollup/plugin-commonjs'
+import json from '@rollup/plugin-json'
+import {nodeResolve} from '@rollup/plugin-node-resolve'
 
 const name = pkg.name
 const license = fs.readFileSync('LICENSE').toString('utf-8').trim()
@@ -16,9 +19,7 @@ const banner = `
  */
 `.trim()
 
-const external = Object.keys(pkg.dependencies)
-
-/** @type {import('rollup').RollupOptions} */
+const external = Object.keys(pkg.dependencies).filter((dependency) => dependency !== 'elliptic')
 export default [
     {
         input: 'src/index.ts',
@@ -28,7 +29,7 @@ export default [
             format: 'cjs',
             sourcemap: true,
         },
-        plugins: [typescript({target: 'es6'})],
+        plugins: [nodeResolve(), json(), commonjs(), typescript({target: 'es6'})],
         external,
     },
     {
@@ -39,7 +40,7 @@ export default [
             format: 'esm',
             sourcemap: true,
         },
-        plugins: [typescript({target: 'es2020'})],
+        plugins: [nodeResolve(), json(), commonjs(), typescript({target: 'es2020'})],
         external,
     },
     {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,7 +19,9 @@ const banner = `
  */
 `.trim()
 
-const external = Object.keys(pkg.dependencies).filter((dependency) => dependency !== 'elliptic')
+const external = Object.keys(pkg.dependencies).filter(
+    (dependency) => dependency !== 'cborg' && dependency !== 'elliptic'
+)
 export default [
     {
         input: 'src/index.ts',

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,15 +246,14 @@ function getCborItemLength(data: Uint8Array, start: number): number {
             return pos + value - start
         }
 
-        while (true) {
-            if (pos >= data.length) {
-                throw new Error('Unterminated indefinite CBOR string')
-            }
+        while (pos < data.length) {
             if (data[pos] === 0xff) {
                 return pos + 1 - start
             }
             pos += getCborItemLength(data, pos)
         }
+
+        throw new Error('Unterminated indefinite CBOR string')
     }
 
     if (majorType === 4 || majorType === 5) {
@@ -266,15 +265,14 @@ function getCborItemLength(data: Uint8Array, start: number): number {
             return pos - start
         }
 
-        while (true) {
-            if (pos >= data.length) {
-                throw new Error('Unterminated indefinite CBOR container')
-            }
+        while (pos < data.length) {
             if (data[pos] === 0xff) {
                 return pos + 1 - start
             }
             pos += getCborItemLength(data, pos)
         }
+
+        throw new Error('Unterminated indefinite CBOR container')
     }
 
     if (majorType === 6) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
     Signature,
 } from '@wharfkit/antelope'
 import {decode as cborDecode} from 'cborg'
-import {ec} from 'elliptic'
+import elliptic from 'elliptic'
 
 import {Decoder} from './decoder'
 
@@ -19,6 +19,7 @@ export function createPublic(
     },
     logging = false
 ) {
+const {ec} = elliptic
     const clientData = decodeBinaryJson(attestationResponse.clientDataJSON)
     const origin = clientData.origin
     if (typeof origin !== 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
     PublicKey,
     Signature,
 } from '@wharfkit/antelope'
-import {decode as cborDecode} from 'cborg'
+import {decode as cborDecode, decodeFirst} from 'cborg'
 import elliptic from 'elliptic'
 
 import {Decoder} from './decoder'
@@ -208,7 +208,10 @@ function decodeAuthData(authData: Uint8Array) {
     const counter = decoder.readNum(4)
     const aaguid = decoder.readArray(16)
     const credentialId = decoder.readArray(decoder.readNum(2))
-    const credentialPublicKey = decodeFirstCborItem(decoder.remainder()) as Map<number, any>
+    const [credentialPublicKey] = decodeFirst(decoder.remainder(), {useMaps: true}) as [
+        Map<number, any>,
+        Uint8Array
+    ]
 
     return {
         rpIdHash,
@@ -217,135 +220,6 @@ function decodeAuthData(authData: Uint8Array) {
         aaguid,
         credentialId,
         credentialPublicKey,
-    }
-}
-
-function decodeFirstCborItem(data: Uint8Array): unknown {
-    const length = getCborItemLength(data, 0)
-    return cborDecode(data.subarray(0, length), {useMaps: true})
-}
-
-function getCborItemLength(data: Uint8Array, start: number): number {
-    if (start >= data.length) {
-        throw new Error('Unexpected end of CBOR data')
-    }
-
-    const first = data[start]
-    const majorType = first >> 5
-    const additional = first & 0x1f
-
-    const {value, bytesRead, indefinite} = readCborLength(data, start, additional)
-    let pos = start + 1 + bytesRead
-
-    if (majorType === 0 || majorType === 1) {
-        return pos - start
-    }
-
-    if (majorType === 2 || majorType === 3) {
-        if (!indefinite) {
-            return pos + value - start
-        }
-
-        while (pos < data.length) {
-            if (data[pos] === 0xff) {
-                return pos + 1 - start
-            }
-            pos += getCborItemLength(data, pos)
-        }
-
-        throw new Error('Unterminated indefinite CBOR string')
-    }
-
-    if (majorType === 4 || majorType === 5) {
-        const itemCount = indefinite ? -1 : majorType === 5 ? value * 2 : value
-        if (!indefinite) {
-            for (let i = 0; i < itemCount; i++) {
-                pos += getCborItemLength(data, pos)
-            }
-            return pos - start
-        }
-
-        while (pos < data.length) {
-            if (data[pos] === 0xff) {
-                return pos + 1 - start
-            }
-            pos += getCborItemLength(data, pos)
-        }
-
-        throw new Error('Unterminated indefinite CBOR container')
-    }
-
-    if (majorType === 6) {
-        return pos + getCborItemLength(data, pos) - start
-    }
-
-    if (majorType === 7) {
-        if (additional < 24 || additional === 31) {
-            return pos - start
-        }
-        if (additional === 24) {
-            return pos + 1 - start
-        }
-        if (additional === 25) {
-            return pos + 2 - start
-        }
-        if (additional === 26) {
-            return pos + 4 - start
-        }
-        if (additional === 27) {
-            return pos + 8 - start
-        }
-    }
-
-    throw new Error(`Unsupported CBOR major type: ${majorType}`)
-}
-
-function readCborLength(
-    data: Uint8Array,
-    start: number,
-    additional: number
-): {value: number; bytesRead: number; indefinite: boolean} {
-    if (additional < 24) {
-        return {value: additional, bytesRead: 0, indefinite: false}
-    }
-
-    if (additional === 24) {
-        ensureCborBytes(data, start + 1, 1)
-        return {value: data[start + 1], bytesRead: 1, indefinite: false}
-    }
-
-    if (additional === 25) {
-        ensureCborBytes(data, start + 1, 2)
-        const view = new DataView(data.buffer, data.byteOffset + start + 1, 2)
-        return {value: view.getUint16(0), bytesRead: 2, indefinite: false}
-    }
-
-    if (additional === 26) {
-        ensureCborBytes(data, start + 1, 4)
-        const view = new DataView(data.buffer, data.byteOffset + start + 1, 4)
-        return {value: view.getUint32(0), bytesRead: 4, indefinite: false}
-    }
-
-    if (additional === 27) {
-        ensureCborBytes(data, start + 1, 8)
-        const view = new DataView(data.buffer, data.byteOffset + start + 1, 8)
-        const value = Number(view.getBigUint64(0))
-        if (!Number.isSafeInteger(value)) {
-            throw new Error('CBOR length exceeds safe integer range')
-        }
-        return {value, bytesRead: 8, indefinite: false}
-    }
-
-    if (additional === 31) {
-        return {value: 0, bytesRead: 0, indefinite: true}
-    }
-
-    throw new Error(`Invalid CBOR additional information: ${additional}`)
-}
-
-function ensureCborBytes(data: Uint8Array, start: number, length: number): void {
-    if (start + length > data.length) {
-        throw new Error('Unexpected end of CBOR data')
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ function decodeAuthData(authData: Uint8Array) {
     const counter = decoder.readNum(4)
     const aaguid = decoder.readArray(16)
     const credentialId = decoder.readArray(decoder.readNum(2))
-    const credentialPublicKey = cborDecode(decoder.remainder(), {useMaps: true}) as Map<number, any>
+    const credentialPublicKey = decodeFirstCborItem(decoder.remainder()) as Map<number, any>
 
     return {
         rpIdHash,
@@ -215,6 +215,137 @@ function decodeAuthData(authData: Uint8Array) {
         aaguid,
         credentialId,
         credentialPublicKey,
+    }
+}
+
+function decodeFirstCborItem(data: Uint8Array): unknown {
+    const length = getCborItemLength(data, 0)
+    return cborDecode(data.subarray(0, length), {useMaps: true})
+}
+
+function getCborItemLength(data: Uint8Array, start: number): number {
+    if (start >= data.length) {
+        throw new Error('Unexpected end of CBOR data')
+    }
+
+    const first = data[start]
+    const majorType = first >> 5
+    const additional = first & 0x1f
+
+    const {value, bytesRead, indefinite} = readCborLength(data, start, additional)
+    let pos = start + 1 + bytesRead
+
+    if (majorType === 0 || majorType === 1) {
+        return pos - start
+    }
+
+    if (majorType === 2 || majorType === 3) {
+        if (!indefinite) {
+            return pos + value - start
+        }
+
+        while (true) {
+            if (pos >= data.length) {
+                throw new Error('Unterminated indefinite CBOR string')
+            }
+            if (data[pos] === 0xff) {
+                return pos + 1 - start
+            }
+            pos += getCborItemLength(data, pos)
+        }
+    }
+
+    if (majorType === 4 || majorType === 5) {
+        const itemCount = indefinite ? -1 : majorType === 5 ? value * 2 : value
+        if (!indefinite) {
+            for (let i = 0; i < itemCount; i++) {
+                pos += getCborItemLength(data, pos)
+            }
+            return pos - start
+        }
+
+        while (true) {
+            if (pos >= data.length) {
+                throw new Error('Unterminated indefinite CBOR container')
+            }
+            if (data[pos] === 0xff) {
+                return pos + 1 - start
+            }
+            pos += getCborItemLength(data, pos)
+        }
+    }
+
+    if (majorType === 6) {
+        return pos + getCborItemLength(data, pos) - start
+    }
+
+    if (majorType === 7) {
+        if (additional < 24 || additional === 31) {
+            return pos - start
+        }
+        if (additional === 24) {
+            return pos + 1 - start
+        }
+        if (additional === 25) {
+            return pos + 2 - start
+        }
+        if (additional === 26) {
+            return pos + 4 - start
+        }
+        if (additional === 27) {
+            return pos + 8 - start
+        }
+    }
+
+    throw new Error(`Unsupported CBOR major type: ${majorType}`)
+}
+
+function readCborLength(
+    data: Uint8Array,
+    start: number,
+    additional: number
+): {value: number; bytesRead: number; indefinite: boolean} {
+    if (additional < 24) {
+        return {value: additional, bytesRead: 0, indefinite: false}
+    }
+
+    if (additional === 24) {
+        ensureCborBytes(data, start + 1, 1)
+        return {value: data[start + 1], bytesRead: 1, indefinite: false}
+    }
+
+    if (additional === 25) {
+        ensureCborBytes(data, start + 1, 2)
+        const view = new DataView(data.buffer, data.byteOffset + start + 1, 2)
+        return {value: view.getUint16(0), bytesRead: 2, indefinite: false}
+    }
+
+    if (additional === 26) {
+        ensureCborBytes(data, start + 1, 4)
+        const view = new DataView(data.buffer, data.byteOffset + start + 1, 4)
+        return {value: view.getUint32(0), bytesRead: 4, indefinite: false}
+    }
+
+    if (additional === 27) {
+        ensureCborBytes(data, start + 1, 8)
+        const view = new DataView(data.buffer, data.byteOffset + start + 1, 8)
+        const value = Number(view.getBigUint64(0))
+        if (!Number.isSafeInteger(value)) {
+            throw new Error('CBOR length exceeds safe integer range')
+        }
+        return {value, bytesRead: 8, indefinite: false}
+    }
+
+    if (additional === 31) {
+        return {value: 0, bytesRead: 0, indefinite: true}
+    }
+
+    throw new Error(`Invalid CBOR additional information: ${additional}`)
+}
+
+function ensureCborBytes(data: Uint8Array, start: number, length: number): void {
+    if (start + length > data.length) {
+        throw new Error('Unexpected end of CBOR data')
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import elliptic from 'elliptic'
 
 import {Decoder} from './decoder'
 
+const {ec} = elliptic
+
 export function createPublic(
     attestationResponse: {
         attestationObject: ArrayBuffer
@@ -19,7 +21,6 @@ export function createPublic(
     },
     logging = false
 ) {
-const {ec} = elliptic
     const clientData = decodeBinaryJson(attestationResponse.clientDataJSON)
     const origin = clientData.origin
     if (typeof origin !== 'string') {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,5 +1,6 @@
 import {assert} from 'chai'
 import {Bytes, Checksum256, KeyType, PublicKey} from '@wharfkit/antelope'
+import {decode as cborDecode, encode as cborEncode} from 'cborg'
 
 import * as lib from '$lib'
 
@@ -28,6 +29,50 @@ suite('index', function () {
             key,
             'PUB_WA_2NVXH8vKM57G6raNdktPvTuMxBM9EeuK8uquDGhaXPfMV7SMFd4dUgza7xGStLnVJs5Xdhhm5fs'
         )
+    })
+
+    test('createPublic with extension data', function () {
+        const normalResponse = {
+            attestationObject: Bytes.from(
+                'a363666d74646e6f6e656761747453746d74a068617574684461746158980511e9517abcfeaa5db71dddb8ba831' +
+                    'd0513ecdb1bd5f5907421ffa5c909ea3045000000000000000000000000000000000000000000149e093bb39d81' +
+                    'de544b40af3fd3894c9a6d5214eba5010203262001215820d9eee421c986d509f9e575c08f4a3ab45bca6896a69' +
+                    'fb4e83379a8bc9fb6af982258202ddb029af756c10243446b888892d91f82e63c101d5715308cb0155900ec862f'
+            ).array.buffer,
+            clientDataJSON: Bytes.from(
+                '7b2274797065223a22776562617574686e2e637265617465222c2263' +
+                    '68616c6c656e6765223a2276755f367a694b2d375f724f76755f367a' +
+                    '7237762d73346976755f367a7237762d7334222c226f726967696e22' +
+                    '3a2268747470733a2f2f79656c6c6f776167656e74732e636f6d227d'
+            ).array.buffer,
+        }
+
+        const attestationObject = cborDecode(new Uint8Array(normalResponse.attestationObject), {
+            useMaps: true,
+        }) as Map<string, unknown>
+
+        const authData = new Uint8Array(attestationObject.get('authData') as Uint8Array)
+        authData[32] = authData[32] | 0x80
+
+        const extensions = cborEncode(new Map([['credProps', new Map([['rk', true]])]]))
+        const authDataWithExtensions = new Uint8Array(authData.length + extensions.length)
+        authDataWithExtensions.set(authData, 0)
+        authDataWithExtensions.set(extensions, authData.length)
+
+        attestationObject.set('authData', authDataWithExtensions)
+        const encodedAttestationObject = cborEncode(attestationObject)
+        const responseWithExtensions = {
+            ...normalResponse,
+            attestationObject: encodedAttestationObject.buffer.slice(
+                encodedAttestationObject.byteOffset,
+                encodedAttestationObject.byteOffset + encodedAttestationObject.byteLength
+            ),
+        }
+
+        const normalKey = lib.createPublic(normalResponse)
+        const extensionKey = lib.createPublic(responseWithExtensions)
+
+        assert.equal(extensionKey.toString(), normalKey.toString())
     })
 
     test('createSignature', function () {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,8 +1,10 @@
 import {assert} from 'chai'
 import {Bytes, Checksum256, KeyType, PublicKey} from '@wharfkit/antelope'
-import {decode as cborDecode, encode as cborEncode} from 'cborg'
 
-import * as lib from '$lib'
+import * as lib from '../lib/eosio-webauthn.js'
+
+const loadCborg = () =>
+    new Function('return import("cborg")')() as Promise<typeof import('cborg')>
 
 suite('index', function () {
     this.timeout(5000)
@@ -31,7 +33,9 @@ suite('index', function () {
         )
     })
 
-    test('createPublic with extension data', function () {
+    test('createPublic with extension data', async function () {
+        const {decode: cborDecode, encode: cborEncode} = await loadCborg()
+
         const normalResponse = {
             attestationObject: Bytes.from(
                 'a363666d74646e6f6e656761747453746d74a068617574684461746158980511e9517abcfeaa5db71dddb8ba831' +

--- a/yarn.lock
+++ b/yarn.lock
@@ -712,10 +712,10 @@ caniuse-lite@^1.0.30001265:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001270.tgz#cc9c37a4ec5c1a8d616fc7bace902bb053b0cdea"
   integrity sha512-TcIC7AyNWXhcOmv2KftOl1ShFAaHQYcB/EPL/hEyMrcS7ZX0/DvV1aoy6BzV0+16wTpoAyTMGDNAJfSqS/rz7A==
 
-cborg@^1.5.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/cborg/-/cborg-1.5.2.tgz#87964ce85bcb894c8175f3f34eed3fd512aaff6e"
-  integrity sha512-w7RJ0Hm29B/Y5kvUXrP+TfgvBmkRUwYVr8hD63z5MlIGdlelhzNMCV/xKbG+yAyp4euJrqxPsQMXGyJKnfGhPQ==
+cborg@^4.5.8:
+  version "4.5.8"
+  resolved "https://registry.yarnpkg.com/cborg/-/cborg-4.5.8.tgz#49cf664711237e4eb6197c841a2de79163e58c62"
+  integrity sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw==
 
 chai@^4.3.4:
   version "4.3.4"


### PR DESCRIPTION
This updates createPublic on top of recover-potential so attestation authData with extension bytes no longer breaks public key recovery. Final approach: upgrade cborg to 4.x, use decodeFirst() so only the credential public key CBOR item is decoded, bundle cborg because cborg 4 is ESM-only while this package still ships a CJS entry, and keep bundling elliptic so linked/Vite SSR consumers do not hit the CommonJS/ESM interop failure again. Includes regression coverage for extension-bearing attestation data and keeps the branch build/test setup passing.